### PR TITLE
v0.4.0-alpha: UI improvements, bugfixes, enhanced support for existing features

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,8 +58,8 @@ android {
         applicationId = "nl.marc_apps.ovgo"
         minSdk = 26
         targetSdk = 30
-        versionCode = getProperty("version.code")?.toInt() ?: 5
-        versionName = getProperty("version.name") ?: "0.3"
+        versionCode = getProperty("version.code")?.toInt() ?: 6
+        versionName = getProperty("version.name") ?: "0.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments["runnerBuilder"] = "de.mannodermaus.junit5.AndroidJUnit5Builder"

--- a/app/src/main/java/nl/marc_apps/ovgo/data/TrainStationRepository.kt
+++ b/app/src/main/java/nl/marc_apps/ovgo/data/TrainStationRepository.kt
@@ -37,7 +37,7 @@ class TrainStationRepository(
 
     private fun getTrainStationsFromCache(): List<TrainStation>? {
         val cachedTrainStations = trainStationsCache
-        return if (!cachedTrainStations.isNullOrEmpty()) cachedTrainStations else null
+        return if (cachedTrainStations.isNullOrEmpty()) null else cachedTrainStations
     }
 
     private suspend fun getTrainStationsFromDatabase(): List<TrainStation>? {
@@ -50,13 +50,15 @@ class TrainStationRepository(
 
         val databaseTrainStations = trainStationDao.getAll()
 
-        return if (!databaseTrainStations.isNullOrEmpty()) {
+        return if (databaseTrainStations.isNullOrEmpty()) {
+            null
+        } else {
             databaseTrainStations.map {
                 it.asTrainStation()
             }.also {
                 trainStationsCache = it
             }
-        } else null
+        }
     }
 
     private suspend fun getTrainStationsFromApi(): List<TrainStation>? {

--- a/app/src/main/java/nl/marc_apps/ovgo/data/api/HttpClientImpl.kt
+++ b/app/src/main/java/nl/marc_apps/ovgo/data/api/HttpClientImpl.kt
@@ -20,7 +20,7 @@ object HttpClientImpl : HttpClient {
     }
 
     override val okHttpClient = httpClient {
-        if(BuildConfig.DEBUG && LOG_HTTP_REQUESTS_ON_DEBUG) {
+        if (BuildConfig.DEBUG && LOG_HTTP_REQUESTS_ON_DEBUG) {
             addInterceptor(logger)
         }
         callTimeout(1, TimeUnit.MINUTES)

--- a/app/src/main/java/nl/marc_apps/ovgo/data/type_conversions/TrainInfoConversions.kt
+++ b/app/src/main/java/nl/marc_apps/ovgo/data/type_conversions/TrainInfoConversions.kt
@@ -5,11 +5,11 @@ import nl.marc_apps.ovgo.domain.TrainInfo
 import nl.marc_apps.ovgo.data.api.dutch_railways.models.DutchRailwaysTrainInfo.TrainPart.Facility as DutchRailwaysFacility
 
 object TrainInfoConversions {
-    private const val TRAIN_IMAGE_URL_QBUZZ_GTW_6 = "https://marc-jb.github.io/OVgo-api/gtw_qbuzz_26.png"
+    private const val TRAIN_IMAGE_URL_QBUZZ_GTW_6 = "https://marc-jb.github.io/TraiNL-resources/gtw_qbuzz_26.png"
 
-    private const val TRAIN_IMAGE_URL_QBUZZ_GTW_8 = "https://marc-jb.github.io/OVgo-api/gtw_qbuzz_28.png"
+    private const val TRAIN_IMAGE_URL_QBUZZ_GTW_8 = "https://marc-jb.github.io/TraiNL-resources/gtw_qbuzz_28.png"
 
-    private const val TRAIN_IMAGE_URL_EUROSTAR = "https://marc-jb.github.io/OVgo-api/eurostar_e320.png"
+    private const val TRAIN_IMAGE_URL_EUROSTAR = "https://marc-jb.github.io/TraiNL-resources/eurostar_e320.png"
 
     private const val TRAIN_SEAT_COUNT_QBUZZ_GTW_6 = 113
 

--- a/app/src/main/java/nl/marc_apps/ovgo/data/type_conversions/TrainInfoConversions.kt
+++ b/app/src/main/java/nl/marc_apps/ovgo/data/type_conversions/TrainInfoConversions.kt
@@ -24,9 +24,9 @@ object TrainInfoConversions {
     private const val TRAIN_TYPE_EUROSTAR = "Eurostar"
 
     private fun isQbuzzDMG(model: DutchRailwaysTrainInfo): Boolean {
-        return model.operator == OPERATOR_NAME_RNET && model.actualTrainParts.none {
+        return model.journeyNumber in 7100..7299 || (model.operator == OPERATOR_NAME_RNET && model.actualTrainParts.none {
             it.type == TRAIN_TYPE_RNET_BY_NS
-        }
+        })
     }
 
     fun convertApiToDomainModel(model: DutchRailwaysTrainInfo): TrainInfo {

--- a/app/src/main/java/nl/marc_apps/ovgo/ui/DisruptionsAdapter.kt
+++ b/app/src/main/java/nl/marc_apps/ovgo/ui/DisruptionsAdapter.kt
@@ -59,7 +59,7 @@ class DisruptionsAdapter : ListAdapter<DutchRailwaysDisruption, DisruptionsAdapt
                     .show()
             }
         } else if (disruption is DutchRailwaysDisruption.Calamity) {
-            holder.binding.labelTitle.setTextColor(context.getColor(R.color.colorError))
+            holder.binding.labelTitle.setTextColor(context.getColor(R.color.sectionTitleWarningColor))
 
             holder.binding.labelDescription.text = disruption.description
 

--- a/app/src/main/java/nl/marc_apps/ovgo/ui/DisruptionsAdapter.kt
+++ b/app/src/main/java/nl/marc_apps/ovgo/ui/DisruptionsAdapter.kt
@@ -28,7 +28,7 @@ class DisruptionsAdapter : ListAdapter<DutchRailwaysDisruption, DisruptionsAdapt
         holder.binding.labelTitle.text = disruption.title
 
         if (disruption is DutchRailwaysDisruption.DisruptionOrMaintenance) {
-            holder.binding.labelTitle.setTextColor(context.getColor(R.color.colorPrimary))
+            holder.binding.labelTitle.setTextColor(context.getColor(R.color.sectionTitleColor))
 
             val currentDate = Date()
             val activeTimeSpans = disruption.timespans.filterNot { currentDate.after(it.start) && currentDate.before(it.end) }

--- a/app/src/main/java/nl/marc_apps/ovgo/ui/DisruptionsAdapter.kt
+++ b/app/src/main/java/nl/marc_apps/ovgo/ui/DisruptionsAdapter.kt
@@ -1,5 +1,6 @@
 package nl.marc_apps.ovgo.ui
 
+import android.text.format.DateUtils
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -41,6 +42,8 @@ class DisruptionsAdapter : ListAdapter<DutchRailwaysDisruption, DisruptionsAdapt
 
             holder.binding.labelDescription.text = description
 
+            holder.binding.labelLastUpdate.visibility = View.GONE
+
             holder.binding.labelTimerange.visibility = View.VISIBLE
 
             holder.binding.labelTimerange.text = if (disruption.end == null) {
@@ -64,6 +67,17 @@ class DisruptionsAdapter : ListAdapter<DutchRailwaysDisruption, DisruptionsAdapt
             holder.binding.labelDescription.text = disruption.description
 
             holder.binding.labelTimerange.visibility = View.GONE
+
+            if (disruption.lastUpdated == null) {
+                holder.binding.labelLastUpdate.visibility = View.GONE
+            } else {
+                holder.binding.labelLastUpdate.visibility = View.VISIBLE
+                holder.binding.labelLastUpdate.text = DateUtils.getRelativeTimeSpanString(
+                    disruption.lastUpdated.time,
+                    System.currentTimeMillis(),
+                    DateUtils.MINUTE_IN_MILLIS
+                )
+            }
 
             holder.binding.root.setOnClickListener {
                 MaterialAlertDialogBuilder(context)

--- a/app/src/main/java/nl/marc_apps/ovgo/ui/DisruptionsAdapter.kt
+++ b/app/src/main/java/nl/marc_apps/ovgo/ui/DisruptionsAdapter.kt
@@ -35,7 +35,7 @@ class DisruptionsAdapter : ListAdapter<DutchRailwaysDisruption, DisruptionsAdapt
 
             val description = listOfNotNull(
                 activeTimeSpans.firstOrNull()?.situation?.label,
-                disruption.summaryAdditionalTravelTime?.label,
+                disruption.summaryAdditionalTravelTime?.label ?: activeTimeSpans.firstOrNull()?.additionalTravelTime?.label,
                 disruption.expectedDuration?.description
             ).joinToString(separator = " ")
 

--- a/app/src/main/java/nl/marc_apps/ovgo/ui/TrainImageBorderTransformation.kt
+++ b/app/src/main/java/nl/marc_apps/ovgo/ui/TrainImageBorderTransformation.kt
@@ -1,0 +1,51 @@
+package nl.marc_apps.ovgo.ui
+
+import android.graphics.*
+import androidx.core.graphics.applyCanvas
+import androidx.core.graphics.createBitmap
+import coil.bitmap.BitmapPool
+import coil.size.Size
+import coil.transform.Transformation
+
+class TrainImageBorderTransformation(
+    private val key: String,
+    private val strokeWidth: Int = 2,
+    private val color: Int = Color.WHITE
+) : Transformation {
+    override fun key() = "train-image-border:$key:$strokeWidth:$color"
+
+    override suspend fun transform(pool: BitmapPool, input: Bitmap, size: Size): Bitmap {
+        val inputWithRemovedBackground = changeBitmapAlpha(changeBitmapAlpha(input, 0.1f), 10f)
+
+        val doubleStrokeWidth = 2 * strokeWidth
+
+        return createBitmap(input.width + doubleStrokeWidth, input.height + doubleStrokeWidth).applyCanvas {
+            val range = 0..doubleStrokeWidth
+            for (index in range) {
+                drawBitmap(inputWithRemovedBackground, 0f, index.toFloat(), null)
+                if (index != 0) {
+                    drawBitmap(inputWithRemovedBackground, index.toFloat(), 0f, null)
+                }
+                drawBitmap(inputWithRemovedBackground, doubleStrokeWidth.toFloat(), index.toFloat(), null)
+                if (index != doubleStrokeWidth) {
+                    drawBitmap(inputWithRemovedBackground, index.toFloat(), doubleStrokeWidth.toFloat(), null)
+                }
+            }
+            drawColor(color, PorterDuff.Mode.SRC_ATOP)
+            drawBitmap(inputWithRemovedBackground, strokeWidth.toFloat(), strokeWidth.toFloat(), null)
+        }
+    }
+
+    private fun changeBitmapAlpha(bitmap: Bitmap, factor: Float): Bitmap {
+        return createBitmap(bitmap.width, bitmap.height).applyCanvas {
+            drawBitmap(bitmap, 0f, 0f, Paint().apply {
+                this.colorFilter = ColorMatrixColorFilter(floatArrayOf(
+                    1f, 0f, 0f, 0f, 0f,
+                    0f, 1f, 0f, 0f, 0f,
+                    0f, 0f, 1f, 0f, 0f,
+                    0f, 0f, 0f, factor, 0f
+                ))
+            })
+        }
+    }
+}

--- a/app/src/main/java/nl/marc_apps/ovgo/ui/TrainImages.kt
+++ b/app/src/main/java/nl/marc_apps/ovgo/ui/TrainImages.kt
@@ -1,0 +1,35 @@
+package nl.marc_apps.ovgo.ui
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import coil.load
+import nl.marc_apps.ovgo.R
+import nl.marc_apps.ovgo.databinding.PartialTrainImageBinding
+
+object TrainImages {
+    fun loadView(root: ViewGroup, imageUrls: List<String>?) {
+        val shouldDrawImageBorder = root.resources.getBoolean(R.bool.should_draw_train_image_border)
+
+        imageUrls?.forEach {
+            val imageView = PartialTrainImageBinding.inflate(
+                LayoutInflater.from(root.context),
+                root,
+                true
+            )
+
+            val isIce = "ice" in it
+
+            val borderColor = if (isIce) R.color.trainImageBorderAlternative else R.color.trainImageBorder
+            val borderTransformation = TrainImageBorderTransformation(
+                key = it,
+                imageView.root.resources.getDimensionPixelSize(R.dimen.train_image_stroke_width),
+                imageView.root.context.getColor(borderColor)
+            )
+            imageView.root.load(it) {
+                if (isIce || shouldDrawImageBorder) {
+                    transformations(borderTransformation)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/nl/marc_apps/ovgo/ui/departure_board/DepartureBoardFragment.kt
+++ b/app/src/main/java/nl/marc_apps/ovgo/ui/departure_board/DepartureBoardFragment.kt
@@ -59,10 +59,10 @@ class DepartureBoardFragment : Fragment() {
         }
 
         val station = navigationArgs.station
-        if (station != null) {
-            viewModel.loadDepartures(station)
-        } else {
+        if (station == null) {
             viewModel.loadDeparturesForLastKnownStation()
+        } else {
+            viewModel.loadDepartures(station)
         }
     }
 }

--- a/app/src/main/java/nl/marc_apps/ovgo/ui/departure_board/DeparturesAdapter.kt
+++ b/app/src/main/java/nl/marc_apps/ovgo/ui/departure_board/DeparturesAdapter.kt
@@ -62,7 +62,7 @@ class DeparturesAdapter : ListAdapter<Departure, DeparturesAdapter.DepartureView
         val binding = holder.binding
         val context = binding.root.context
 
-        val departureTimeWithDelayText = if(departure.isDelayed) {
+        val departureTimeWithDelayText = if (departure.isDelayed) {
             context.getString(
                 R.string.departure_time_delayed,
                 departure.actualDepartureTime.format(timeStyle = DateFormat.SHORT),
@@ -77,7 +77,7 @@ class DeparturesAdapter : ListAdapter<Departure, DeparturesAdapter.DepartureView
         binding.labelDepartureTime.setTextColor(
             ContextCompat.getColor(
                 binding.labelDepartureTime.context,
-                if(departure.isDelayed) R.color.sectionTitleWarningColor else R.color.sectionTitleColor
+                if (departure.isDelayed) R.color.sectionTitleWarningColor else R.color.sectionTitleColor
             )
         )
 
@@ -86,17 +86,17 @@ class DeparturesAdapter : ListAdapter<Departure, DeparturesAdapter.DepartureView
         val upcomingStations = departure.stationsOnRoute.joinToString(limit = MAX_STATIONS_DISPLAYED_ON_ROUTE) {
             it.name
         }
-        binding.labelUpcomingStations.text = if(departure.stationsOnRoute.isNotEmpty()) {
+        binding.labelUpcomingStations.text = if (departure.stationsOnRoute.isNotEmpty()) {
             context.getString(R.string.departure_via_stations, upcomingStations)
         } else {
             ""
         }
         binding.labelUpcomingStations.visibility =
-            if(departure.stationsOnRoute.isEmpty()) View.GONE
+            if (departure.stationsOnRoute.isEmpty()) View.GONE
             else View.VISIBLE
 
         binding.labelPlatform.setBackgroundResource(
-            if(departure.platformChanged) R.drawable.platform_background_style_red
+            if (departure.platformChanged) R.drawable.platform_background_style_red
             else R.drawable.platform_background_style
         )
         binding.labelPlatform.text = departure.actualTrack
@@ -120,7 +120,7 @@ class DeparturesAdapter : ListAdapter<Departure, DeparturesAdapter.DepartureView
     }
 
     private fun loadTrainImages(binding: ListItemDepartureBinding, trainInfo: TrainInfo?) {
-        binding.holderTrainImagesScrollable.visibility = if(trainInfo?.trainParts?.firstOrNull()?.imageUrl == null) {
+        binding.holderTrainImagesScrollable.visibility = if (trainInfo?.trainParts?.firstOrNull()?.imageUrl == null) {
             View.GONE
         } else {
             View.VISIBLE
@@ -144,7 +144,7 @@ class DeparturesAdapter : ListAdapter<Departure, DeparturesAdapter.DepartureView
 
         binding.labelDirection.text = departure.direction?.name
 
-        binding.labelCancelled.visibility = if(departure.isCancelled) View.VISIBLE else View.GONE
+        binding.labelCancelled.visibility = if (departure.isCancelled) View.VISIBLE else View.GONE
 
         binding.labelOperatorAndType.text = if (departure.operator == departure.categoryName) {
             departure.operator
@@ -160,7 +160,7 @@ class DeparturesAdapter : ListAdapter<Departure, DeparturesAdapter.DepartureView
     @Type
     override fun getItemViewType(position: Int): Int {
         val departure = currentList.elementAtOrNull(position)
-        return if(departure?.isCancelled == false) TYPE_REGULAR else TYPE_CANCELLED
+        return if (departure?.isCancelled == true) TYPE_CANCELLED else TYPE_REGULAR
     }
 
     sealed class DepartureViewHolder(view: View) : RecyclerView.ViewHolder(view) {

--- a/app/src/main/java/nl/marc_apps/ovgo/ui/departure_board/DeparturesAdapter.kt
+++ b/app/src/main/java/nl/marc_apps/ovgo/ui/departure_board/DeparturesAdapter.kt
@@ -74,7 +74,7 @@ class DeparturesAdapter : ListAdapter<Departure, DeparturesAdapter.DepartureView
         binding.labelDepartureTime.setTextColor(
             ContextCompat.getColor(
                 binding.labelDepartureTime.context,
-                if(departure.isDelayed) R.color.colorError else R.color.colorPrimary
+                if(departure.isDelayed) R.color.sectionTitleWarningColor else R.color.sectionTitleColor
             )
         )
 

--- a/app/src/main/java/nl/marc_apps/ovgo/ui/departure_board/DeparturesAdapter.kt
+++ b/app/src/main/java/nl/marc_apps/ovgo/ui/departure_board/DeparturesAdapter.kt
@@ -1,6 +1,5 @@
 package nl.marc_apps.ovgo.ui.departure_board
 
-import android.graphics.Color
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -10,14 +9,11 @@ import androidx.navigation.findNavController
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import coil.load
 import nl.marc_apps.ovgo.R
 import nl.marc_apps.ovgo.databinding.ListItemDepartureBinding
 import nl.marc_apps.ovgo.databinding.ListItemDepartureCancelledBinding
-import nl.marc_apps.ovgo.databinding.PartialTrainImageBinding
 import nl.marc_apps.ovgo.domain.Departure
 import nl.marc_apps.ovgo.domain.TrainInfo
-import nl.marc_apps.ovgo.ui.TrainImageBorderTransformation
 import nl.marc_apps.ovgo.ui.TrainImages
 import nl.marc_apps.ovgo.utils.format
 import java.text.DateFormat

--- a/app/src/main/java/nl/marc_apps/ovgo/ui/departure_board/DeparturesAdapter.kt
+++ b/app/src/main/java/nl/marc_apps/ovgo/ui/departure_board/DeparturesAdapter.kt
@@ -1,5 +1,6 @@
 package nl.marc_apps.ovgo.ui.departure_board
 
+import android.graphics.Color
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -16,6 +17,8 @@ import nl.marc_apps.ovgo.databinding.ListItemDepartureCancelledBinding
 import nl.marc_apps.ovgo.databinding.PartialTrainImageBinding
 import nl.marc_apps.ovgo.domain.Departure
 import nl.marc_apps.ovgo.domain.TrainInfo
+import nl.marc_apps.ovgo.ui.TrainImageBorderTransformation
+import nl.marc_apps.ovgo.ui.TrainImages
 import nl.marc_apps.ovgo.utils.format
 import java.text.DateFormat
 
@@ -127,13 +130,8 @@ class DeparturesAdapter : ListAdapter<Departure, DeparturesAdapter.DepartureView
             binding.holderTrainImages.removeViews(LAYOUT_CHILD_COUNT_SINGLE_VIEW, binding.holderTrainImages.childCount - LAYOUT_CHILD_COUNT_SINGLE_VIEW)
         }
 
-        trainInfo?.trainParts?.forEach {
-            val imageView = PartialTrainImageBinding.inflate(
-                LayoutInflater.from(binding.holderTrainImages.context),
-                binding.holderTrainImages,
-                true
-            )
-            imageView.root.load(it.imageUrl)
+        trainInfo?.trainParts?.mapNotNull { it.imageUrl }?.let {
+            TrainImages.loadView(binding.holderTrainImages, it)
         }
     }
 

--- a/app/src/main/java/nl/marc_apps/ovgo/ui/departure_details/DepartureDetailsFragment.kt
+++ b/app/src/main/java/nl/marc_apps/ovgo/ui/departure_details/DepartureDetailsFragment.kt
@@ -49,7 +49,7 @@ class DepartureDetailsFragment : Fragment() {
         binding.labelDepartureTime.setTextColor(
             ContextCompat.getColor(
                 view.context,
-                if(departure.isDelayed || departure.isCancelled) R.color.colorError else R.color.colorPrimary
+                if(departure.isDelayed || departure.isCancelled) R.color.sectionTitleWarningColor else R.color.sectionTitleColor
             )
         )
 
@@ -57,7 +57,7 @@ class DepartureDetailsFragment : Fragment() {
         binding.labelDirection.setTextColor(
             ContextCompat.getColor(
                 binding.labelDirection.context,
-                if(departure.isCancelled) R.color.colorError else R.color.colorPrimary
+                if(departure.isCancelled) R.color.sectionTitleWarningColor else R.color.sectionTitleColor
             )
         )
 

--- a/app/src/main/java/nl/marc_apps/ovgo/ui/departure_details/DepartureDetailsFragment.kt
+++ b/app/src/main/java/nl/marc_apps/ovgo/ui/departure_details/DepartureDetailsFragment.kt
@@ -13,6 +13,8 @@ import nl.marc_apps.ovgo.databinding.FragmentDepartureDetailsBinding
 import nl.marc_apps.ovgo.databinding.PartialTrainImageBinding
 import nl.marc_apps.ovgo.domain.Departure
 import nl.marc_apps.ovgo.domain.TrainInfo
+import nl.marc_apps.ovgo.ui.TrainImageBorderTransformation
+import nl.marc_apps.ovgo.ui.TrainImages
 import nl.marc_apps.ovgo.utils.format
 import java.text.DateFormat
 
@@ -128,13 +130,9 @@ class DepartureDetailsFragment : Fragment() {
             else View.VISIBLE
 
         binding.holderTrainImages.removeAllViews()
-        trainInfo?.trainParts?.forEach {
-            val imageView = PartialTrainImageBinding.inflate(
-                LayoutInflater.from(binding.holderTrainImages.context),
-                binding.holderTrainImages,
-                true
-            )
-            imageView.root.load(it.imageUrl)
+
+        trainInfo?.trainParts?.mapNotNull { it.imageUrl }?.let {
+            TrainImages.loadView(binding.holderTrainImages, it)
         }
     }
 }

--- a/app/src/main/java/nl/marc_apps/ovgo/ui/departure_details/DepartureDetailsFragment.kt
+++ b/app/src/main/java/nl/marc_apps/ovgo/ui/departure_details/DepartureDetailsFragment.kt
@@ -38,7 +38,7 @@ class DepartureDetailsFragment : Fragment() {
         val departure = navigationArgs.departure
         val trainInfo = departure.trainInfo
 
-        binding.labelDepartureTime.text = if(departure.isDelayed) {
+        binding.labelDepartureTime.text = if (departure.isDelayed) {
             view.context.getString(
                 R.string.departure_time_delayed,
                 departure.actualDepartureTime.format(timeStyle = DateFormat.SHORT),
@@ -51,7 +51,7 @@ class DepartureDetailsFragment : Fragment() {
         binding.labelDepartureTime.setTextColor(
             ContextCompat.getColor(
                 view.context,
-                if(departure.isDelayed || departure.isCancelled) R.color.sectionTitleWarningColor else R.color.sectionTitleColor
+                if (departure.isDelayed || departure.isCancelled) R.color.sectionTitleWarningColor else R.color.sectionTitleColor
             )
         )
 
@@ -59,28 +59,28 @@ class DepartureDetailsFragment : Fragment() {
         binding.labelDirection.setTextColor(
             ContextCompat.getColor(
                 binding.labelDirection.context,
-                if(departure.isCancelled) R.color.sectionTitleWarningColor else R.color.sectionTitleColor
+                if (departure.isCancelled) R.color.sectionTitleWarningColor else R.color.sectionTitleColor
             )
         )
 
         val upcomingStations = departure.stationsOnRoute.joinToString { it.name }
-        binding.labelUpcomingStations.text = if(departure.stationsOnRoute.isNotEmpty()) {
+        binding.labelUpcomingStations.text = if (departure.stationsOnRoute.isNotEmpty()) {
             view.context.getString(R.string.departure_via_stations, upcomingStations)
         } else {
             ""
         }
         binding.labelUpcomingStations.visibility =
-            if(departure.stationsOnRoute.isEmpty() || departure.isCancelled) View.GONE
+            if (departure.stationsOnRoute.isEmpty() || departure.isCancelled) View.GONE
             else View.VISIBLE
 
-        binding.labelCancelled.visibility = if(departure.isCancelled) View.VISIBLE else View.GONE
+        binding.labelCancelled.visibility = if (departure.isCancelled) View.VISIBLE else View.GONE
 
         binding.labelPlatform.setBackgroundResource(
-            if(departure.platformChanged || departure.isCancelled) R.drawable.platform_background_style_red
+            if (departure.platformChanged || departure.isCancelled) R.drawable.platform_background_style_red
             else R.drawable.platform_background_style
         )
         binding.labelPlatform.text = departure.actualTrack
-        binding.labelPlatform.visibility = if(departure.isCancelled) View.GONE else View.VISIBLE
+        binding.labelPlatform.visibility = if (departure.isCancelled) View.GONE else View.VISIBLE
 
         loadFacilities(departure, trainInfo)
 
@@ -96,37 +96,37 @@ class DepartureDetailsFragment : Fragment() {
     private fun loadFacilities(departure: Departure, trainInfo: TrainInfo?) {
         val facilities = trainInfo?.facilities ?: TrainInfo.TrainFacilities()
         binding.iconWheelchairAccessible.visibility =
-            if(!departure.isCancelled && facilities.isWheelChairAccessible) View.VISIBLE
+            if (!departure.isCancelled && facilities.isWheelChairAccessible) View.VISIBLE
             else View.GONE
 
         binding.iconToilet.visibility =
-            if(!departure.isCancelled && facilities.hasToilet) View.VISIBLE
+            if (!departure.isCancelled && facilities.hasToilet) View.VISIBLE
             else View.GONE
 
         binding.iconBicycles.visibility =
-            if(!departure.isCancelled && facilities.hasBicycleCompartment) View.VISIBLE
+            if (!departure.isCancelled && facilities.hasBicycleCompartment) View.VISIBLE
             else View.GONE
 
         binding.iconWifi.visibility =
-            if(!departure.isCancelled && facilities.hasFreeWifi) View.VISIBLE
+            if (!departure.isCancelled && facilities.hasFreeWifi) View.VISIBLE
             else View.GONE
 
         binding.iconPowerSockets.visibility =
-            if(!departure.isCancelled && facilities.hasPowerSockets) View.VISIBLE
+            if (!departure.isCancelled && facilities.hasPowerSockets) View.VISIBLE
             else View.GONE
 
         binding.iconSilenceCompartment.visibility =
-            if(!departure.isCancelled && facilities.hasSilenceCompartment) View.VISIBLE
+            if (!departure.isCancelled && facilities.hasSilenceCompartment) View.VISIBLE
             else View.GONE
 
         binding.labelFirstClass.visibility =
-            if(!departure.isCancelled && facilities.hasFirstClass) View.VISIBLE
+            if (!departure.isCancelled && facilities.hasFirstClass) View.VISIBLE
             else View.GONE
     }
 
     private fun loadTrainImages(departure: Departure, trainInfo: TrainInfo?) {
         binding.holderTrainImagesScrollable.visibility =
-            if(departure.isCancelled || trainInfo?.trainParts?.firstOrNull()?.imageUrl == null) View.GONE
+            if (departure.isCancelled || trainInfo?.trainParts?.firstOrNull()?.imageUrl == null) View.GONE
             else View.VISIBLE
 
         binding.holderTrainImages.removeAllViews()

--- a/app/src/main/java/nl/marc_apps/ovgo/ui/departure_details/DepartureDetailsFragment.kt
+++ b/app/src/main/java/nl/marc_apps/ovgo/ui/departure_details/DepartureDetailsFragment.kt
@@ -7,13 +7,10 @@ import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
-import coil.load
 import nl.marc_apps.ovgo.R
 import nl.marc_apps.ovgo.databinding.FragmentDepartureDetailsBinding
-import nl.marc_apps.ovgo.databinding.PartialTrainImageBinding
 import nl.marc_apps.ovgo.domain.Departure
 import nl.marc_apps.ovgo.domain.TrainInfo
-import nl.marc_apps.ovgo.ui.TrainImageBorderTransformation
 import nl.marc_apps.ovgo.ui.TrainImages
 import nl.marc_apps.ovgo.utils.format
 import java.text.DateFormat

--- a/app/src/main/java/nl/marc_apps/ovgo/ui/search_station/StationSuggestionsAdapter.kt
+++ b/app/src/main/java/nl/marc_apps/ovgo/ui/search_station/StationSuggestionsAdapter.kt
@@ -25,7 +25,7 @@ class StationSuggestionsAdapter : ListAdapter<TrainStation, StationSuggestionsAd
 
         holder.binding.labelPrimaryName.text = stationSuggestion.name
 
-        if(stationSuggestion.alternativeNames.isEmpty()) {
+        if (stationSuggestion.alternativeNames.isEmpty()) {
             holder.binding.labelSecondaryNames.visibility = View.GONE
         } else {
             holder.binding.labelSecondaryNames.text = stationSuggestion.alternativeNames.joinToString()

--- a/app/src/main/java/nl/marc_apps/ovgo/utils/NullableDateSerializer.kt
+++ b/app/src/main/java/nl/marc_apps/ovgo/utils/NullableDateSerializer.kt
@@ -50,7 +50,7 @@ object NullableDateSerializer : KSerializer<Date?> {
 
     @ExperimentalSerializationApi
     override fun serialize(encoder: Encoder, value: Date?) {
-        if(value == null) {
+        if (value == null) {
             encoder.encodeNull()
         } else {
             encoder.encodeString(JsonDateTime.defaultParser.format(value))

--- a/app/src/main/res/layout/list_item_disruption.xml
+++ b/app/src/main/res/layout/list_item_disruption.xml
@@ -47,4 +47,14 @@
         app:layout_constraintTop_toBottomOf="@id/label_description"
         tools:text="26 mei 2019, 10:30\n28 mei 2019, 18:00" />
 
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/label_last_update"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:textAppearance="@style/TextAppearance.OVgo.Disruption.SubText"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/label_description"
+        tools:text="Eén uur geleden" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-night/bools.xml
+++ b/app/src/main/res/values-night/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="should_draw_train_image_border">true</bool>
+</resources>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -2,6 +2,6 @@
 <resources>
     <color name="backgroundColor">#212121</color>
 
-    <color name="sectionTitleWarningColor">@color/colorError</color>
+    <color name="sectionTitleWarningColor">@color/colorErrorLight</color>
     <color name="sectionTitleColor">@color/colorPrimaryLight</color>
 </resources>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -3,5 +3,6 @@
     <color name="backgroundColor">#212121</color>
 
     <color name="sectionTitleWarningColor">@color/colorErrorLight</color>
-    <color name="sectionTitleColor">@color/colorPrimaryLight</color>
+    <color name="sectionTitleColor">#FFFFFF</color>
 </resources>
+

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="backgroundColor">#212121</color>
+
+    <color name="sectionTitleWarningColor">@color/colorError</color>
+    <color name="sectionTitleColor">@color/colorPrimaryLight</color>
 </resources>

--- a/app/src/main/res/values/bools.xml
+++ b/app/src/main/res/values/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="should_draw_train_image_border">false</bool>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -23,7 +23,7 @@
 
     <!-- Specific colors -->
     <color name="backgroundColor">#FAFAFA</color>
-c
+
     <color name="sectionTitleWarningColor">@color/colorError</color>
     <color name="sectionTitleColor">@color/colorPrimary</color>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -27,4 +27,7 @@ c
     <color name="sectionTitleWarningColor">@color/colorError</color>
     <color name="sectionTitleColor">@color/colorPrimary</color>
 
+    <color name="trainImageBorder">#FAFAFA</color>
+    <color name="trainImageBorderAlternative">@color/colorPrimary</color>
+
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Application color palette -->
     <color name="colorPrimaryLight">#63a4ff</color>
     <color name="colorOnPrimaryLight">#000000</color>
     <color name="colorPrimary">#1976d2</color>
@@ -15,8 +16,15 @@
     <color name="colorOnAccentDark">#000000</color>
 
     <color name="colorOK">#388E3C</color>
+    <color name="colorOKLight">#6ABF69</color>
 
     <color name="colorError">#B00020</color>
+    <color name="colorErrorLight">#E94948</color>
 
+    <!-- Specific colors -->
     <color name="backgroundColor">#FAFAFA</color>
+c
+    <color name="sectionTitleWarningColor">@color/colorError</color>
+    <color name="sectionTitleColor">@color/colorPrimary</color>
+
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -2,4 +2,5 @@
 <resources>
     <dimen name="train_image_spacing_start">104dp</dimen>
     <dimen name="train_image_height">40dp</dimen>
+    <dimen name="train_image_stroke_width">3dp</dimen>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -10,7 +10,7 @@
     <!-- Main text styles -->
 
     <style name="TextAppearance.OVgo.SectionTitle" parent="@style/TextAppearance.MaterialComponents.Body2">
-        <item name="android:textColor">?attr/colorPrimary</item>
+        <item name="android:textColor">@color/sectionTitleColor</item>
         <item name="android:textStyle">bold</item>
     </style>
 
@@ -40,7 +40,7 @@
     <style name="TextAppearance.OVgo.Departure.OperatorAndCategory.Medium" parent="@style/TextAppearance.OVgo.SectionText.Medium" />
 
     <style name="TextAppearance.OVgo.Departure.Cancelled" parent="@style/TextAppearance.OVgo.SectionText.Medium">
-        <item name="android:textColor">@color/colorError</item>
+        <item name="android:textColor">@color/sectionTitleWarningColor</item>
         <item name="android:textStyle">bold</item>
     </style>
 


### PR DESCRIPTION
**UI**
- Text colors in night mode have been updated to improve readability and the overall visual appearance.
- Train images have white borders in dark mode to improve contrast. The ICE - a white train - has a colored border in both light and dark mode.

**Bugfixes**
- Fixed a bug that caused some train images to not load at all.
- Fixed a bug where wrong train images were displayed for the trains service between Dordrecht and Gorinchem or Geldermalsen, which is being run by Qbuzz.

**Enhancements**
- High-priority disruptions now show the time of the last update.
- The amount of additional travel time is shown for more disruptions and maintenance notices.